### PR TITLE
style(StaticCell): remove subtitle marginStart style prop

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -138,7 +138,6 @@ export const staticCellStyles = StyleSheet.create({
 	subtitle: (palette, disabled) => ({
 		alignSelf: 'flex-start',
 
-		marginStart: 4,
 		marginTop: 1,
 		fontSize: 15,
 		color: disabled ? palette.disabled : palette.subtitle,


### PR DESCRIPTION
I just removed the useless `marginStart` style prop on `StaticCell:subtitle`.
Here is the difference with screenshots, and I don't see the interest of having this margin. I know we can override it with the `subtitleStyle` prop, but if it can be applied by default, it's better.

Before:
<img width="503" alt="Screenshot 2019-08-28 at 10 12 55" src="https://user-images.githubusercontent.com/6815295/63838113-098f6c00-c97d-11e9-9799-728c204e1162.png">
After:
<img width="503" alt="Screenshot 2019-08-28 at 10 13 06" src="https://user-images.githubusercontent.com/6815295/63838128-0d22f300-c97d-11e9-8c74-9bef9fd6549a.png">

Furthermore, the behaviour is not consistent, as the `BioCell` `subtitle` component does not have margin:
<img width="506" alt="Screenshot 2019-08-29 at 10 31 25" src="https://user-images.githubusercontent.com/6815295/63924491-a965fc00-ca48-11e9-9836-e320c0dcf029.png">