### PR TITLE
Disable SwitchCell tap on iOS

### DIFF
--- a/src/SwitchCell.js
+++ b/src/SwitchCell.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Switch, Text, View } from 'react-native';
+import { Switch, Text, View, Platform } from 'react-native';
 import PropTypes from 'prop-types';
 
 import AccessoryCell from './AccessoryCell';
@@ -80,7 +80,7 @@ class SwitchCell extends Component {
 			<AccessoryCell
 				hideAccessorySeparator
 				disabled={disabled}
-				onPress={onSwitch}
+				onPress={Platform.OS === 'android' ? onSwitch : null}
 				{...remainingProps}
 				customActionTrigger='onLongPress'
 			>


### PR DESCRIPTION
In this library, `onSwitch` event is called both when the `SwitchCell` itself and the switch are pressed.

In the native applications of both OS, In Android's ListView, the switch is also toggled when the cell is pressed, but in iOS' UITableView, it is only toggled when the Switch itself is pressed.

So I made a small change so that the event is called by tapping the `SwitchCell` itself only on Android.