### PR TITLE
feat: add cell maxline constraint

### DIFF
--- a/src/KeyValueCell.js
+++ b/src/KeyValueCell.js
@@ -47,14 +47,14 @@ class KeyValueCell extends Component {
 		const getTitle = () => {
 			if (title) {
 				const combinedStyles = [styles.title(colorPalette, disabled), titleStyle];
-				return <Text key='title' style={combinedStyles}>{title}</Text>;
+				return <Text key='title' style={combinedStyles} numberOfLines={1} ellipsizeMode='tail'>{title}</Text>;
 			}
 		};
 
 		const getValue = () => {
 			if (value) {
 				const combinedStyles = [styles.value(colorPalette, disabled), valueStyle];
-				return <Text key='value' style={combinedStyles}>{value}</Text>;
+				return <Text key='value' style={combinedStyles} numberOfLines={1} ellipsizeMode='tail'>{value}</Text>;
 			}
 		};
 

--- a/src/StaticCell.js
+++ b/src/StaticCell.js
@@ -46,14 +46,14 @@ class StaticCell extends Component {
 		const renderTitle = () => {
 			if (title) {
 				const combinedStyles = [styles.title(colorPalette, disabled), titleStyle];
-				return <Text key='title' style={combinedStyles}>{title}</Text>;
+				return <Text key='title' style={combinedStyles} numberOfLines={1} ellipsizeMode='tail'>{title}</Text>;
 			}
 		};
 
 		const renderSubtitle = () => {
 			if (subtitle) {
 				const combinedStyles = [styles.subtitle(colorPalette, disabled), subtitleStyle];
-				return <Text key='subtitle' style={combinedStyles}>{subtitle}</Text>;
+				return <Text key='subtitle' style={combinedStyles} numberOfLines={1} ellipsizeMode='tail'>{subtitle}</Text>;
 			}
 		};
 

--- a/src/SwitchCell.js
+++ b/src/SwitchCell.js
@@ -46,7 +46,7 @@ class SwitchCell extends Component {
 		const renderTitle = () => {
 			if (title) {
 				const combinedStyles = [styles.title(colorPalette, disabled), titleStyle];
-				return <Text key='title' style={combinedStyles}>{title}</Text>;
+				return <Text key='title' style={combinedStyles} numberOfLines={1} ellipsizeMode='tail'>{title}</Text>;
 			}
 		};
 


### PR DESCRIPTION
Add cell max-line constraint for KeyValueCell, StaticCell, SwitchCell

Example: 
<img width="453" alt="image" src="https://github.com/mohakapt/react-native-js-tableview/assets/26663836/f000d76a-29c2-4507-a5ec-ece61b05a7b9">
